### PR TITLE
Improve docs and their organization

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Welcome to stimpool's documentation!
 
    readme
    installation
-   stimpool
+   Word Pool <words>
    changelog
    Code of conduct <CODE_OF_CONDUCT.md>
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -4,4 +4,4 @@ stimpool
 .. toctree::
    :maxdepth: 4
 
-    words
+   stimpool

--- a/docs/stimpool.rst
+++ b/docs/stimpool.rst
@@ -1,9 +1,29 @@
-stimpool functionality
-======================
+stimpool package
+================
 
-Word pools (stimpool.words)
----------------------------
+Submodules
+----------
 
-.. autoclass:: stimpool.words.WordPool
+stimpool.cli module
+-------------------
+
+.. automodule:: stimpool.cli
    :members:
    :undoc-members:
+   :show-inheritance:
+
+stimpool.words module
+---------------------
+
+.. automodule:: stimpool.words
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: stimpool
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/words.rst
+++ b/docs/words.rst
@@ -1,0 +1,8 @@
+Word pool (stimpool.words)
+==========================
+
+The WordPool class contains all the functionality for creating word pools. It contains methods for sampling from the pool, selecting words based on their characteristics, getting the cleaned word pool, and saving it to a file.
+
+.. autoclass:: stimpool.words.WordPool
+   :members:
+   :undoc-members:


### PR DESCRIPTION
Improve docs and their organization

## Proposed Changes
- Move word module docs to a separate file
- Change the stimpool for the words module in the index
- Let docs that are built by default be as they are by default
