### PR TITLE
Wrong path used for default word pool

### DIFF
--- a/src/stimpool/words.py
+++ b/src/stimpool/words.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Iterable, Optional, Tuple
 
 import pandas as pd
 
-ROOT_DIR = Path().resolve()
+ROOT_DIR = Path(__file__).resolve().parent
 
 
 class WordPool(object):
@@ -74,7 +74,7 @@ class WordPool(object):
     def _get_default_pool(self) -> pd.Series:
         """Get the default word pool."""
 
-        path = ROOT_DIR / "src" / "stimpool" / "words" / "es_PR.dic"
+        path = ROOT_DIR / "words" / "es_PR.dic"
         pool = pd.read_csv(path, squeeze=True)
 
         return pool


### PR DESCRIPTION
## 🐛 Bug Report

The wrong path is being used to read the default word pool. It is using the path from the cwd and not from the stimpool's root.
## 🔬 How To Reproduce

Steps to reproduce the behavior:

1. Create and instance of the WordPool object without passing a poll argument.

### Code sample

```python
from stimpool.words import WordPool
word_pool = WordPool()
```

### Environment

* OS: [macOS]
* Python version, get it with: 3.7

## 📈 Expected behavior

This should return a wordpool object with that used the default word pool.

<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/ISSUE_TEMPLATE/bug_report.md -->
