### PR TITLE
Simplify the api to WordPool object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Easily create stimuli pools for cognitive, learning, and psycholinguistics resea
 
 ### Usage
 ```python
-from stimpool.words import WordPool
+from stimpool import WordPool
 words = ["gato", "canción", "oso", "otorrinolaringólogo"]
 word_pool = WordPool(words)
 word_pool.select_words_without_accented_characters()

--- a/src/stimpool/__init__.py
+++ b/src/stimpool/__init__.py
@@ -1,5 +1,7 @@
 """Top-level package for stimpool."""
 
+from .words import WordPool  # noqa: F401
+
 __author__ = """Mario E. Bermonti Pérez"""
 __email__ = "mbermonti1132@gmail.com"
 __version__ = "0.2.1"

--- a/tests/test_words.py
+++ b/tests/test_words.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import pandas as pd
 import pytest
 
-from stimpool.words import WordPool
+from stimpool import WordPool
 
 
 def test_get_default_pool() -> None:


### PR DESCRIPTION
## 🚀 Change that should be made
<!-- A clear and concise description of the change proposed. -->
Allow the user access the WordPool object from the package level.

This would allow to access it this way `from stimpool import WordPool`, instead of
`from stimpool import WordPool`.

## 🔈 Motivation

<!-- Please describe the motivation for this proposal. -->
This would simplify the api.


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/ISSUE_TEMPLATE/feature_request.md -->