### PR TITLE
[bump] Bump stimpool version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = True
-current_version = 0.2.2
+current_version = 0.2.3
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2021-08-25
+This release contains the same changes as 0.2.2 (previous). The draft for the previous
+release was discarded by mistake and bumping the version again could fix this.
+- Improve the ease of use
+- Improve the docs
+- Improve the ci actions
+- Minor improvements of internal codebase
+
 ## [0.2.2] - 2021-08-25
 - Improve the ease of use
 - Improve the docs
@@ -32,7 +40,8 @@ the release action on the ci.
 ### Added
 - First release on PyPI.
 
-[Unreleased]: https://github.com/mario-bermonti/stimpool/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/mario-bermonti/stimpool/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/mario-bermonti/stimpool/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/mario-bermonti/stimpool/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/mario-bermonti/stimpool/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/mario-bermonti/stimpool/compare/v0.1.1...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.poetry]
 name = "stimpool"
-version = "0.2.2"
+version = "0.2.3"
 description = "Create stimuli pools for psychological research"
 authors = ["Mario E. Bermonti Pérez <mbermonti1132@gmail.com>"]
 

--- a/src/stimpool/__init__.py
+++ b/src/stimpool/__init__.py
@@ -4,4 +4,4 @@ from .words import WordPool  # noqa: F401
 
 __author__ = """Mario E. Bermonti Pérez"""
 __email__ = "mbermonti1132@gmail.com"
-__version__ = "0.2.2"
+__version__ = "0.2.3"


### PR DESCRIPTION
-------

## Description

<!-- Add a detailed description of the changes if needed. -->
Bump stimpool's version to 0.2.2

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change that fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [x] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->