### PR TITLE
[fix bug] Sample the word_pool internally

### DIFF
--- a/src/stimpool/words.py
+++ b/src/stimpool/words.py
@@ -267,7 +267,7 @@ class WordPool(object):
         return pool_cleaned
 
     def sample_pool(self, n: int, reproducible: bool = True) -> pd.Series:
-        """Return a sample from the word pool.
+        """Sample from the word pool.
 
         This is just a helper function that uses pandas.Series.sample.
         You can read its [complete documentation]
@@ -282,18 +282,13 @@ class WordPool(object):
             Specifies whether the sample obtained should be reproducible.
             This is important to guarantee the reproducibility of
             research (Default=True)
-
-        Returns
-        -------
-        pd.Series
-            pool sample of specified size
         """
 
         reproducible_coded: Optional[int] = 1 if True else None
 
-        sample = self._pool_cleaned.sample(n=n, random_state=reproducible_coded)
-
-        return sample
+        self._pool_cleaned = self._pool_cleaned.sample(
+            n=n, random_state=reproducible_coded
+        )
 
     def save_pool(self, filename: str = "word pool") -> None:
         """Save the word pool to a csv file.

--- a/tests/test_words.py
+++ b/tests/test_words.py
@@ -274,8 +274,10 @@ def test_clean_conjugation_suffixes(words: List[str], exp: List[Optional[str]]) 
 def test_sample_pool_is_reproducible(words: List[str]) -> None:
     """Test that sample_pool is reproducible."""
 
-    word_pool = WordPool(words)
-    obs1 = word_pool.sample_pool(n=3)
-    obs2 = word_pool.sample_pool(n=3)
+    word_pool1 = WordPool(words)
+    word_pool1.sample_pool(n=3)
 
-    obs1.equals(obs2)
+    word_pool2 = WordPool(words)
+    word_pool2.sample_pool(n=3)
+
+    word_pool1.words.equals(word_pool2.words)


### PR DESCRIPTION
Required to change the code, its docstring, and the test.

## Description

<!-- Add a detailed description of the changes if needed. -->


## Related Issue
This fix #122

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change that fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've formatted the code style according to the project's
  standards using `poetry run invoke format`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in following [numpy's format][numpy_style]
  for all the methods and classes that I used.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md
[numpy_style]: https://numpydoc.readthedocs.io/en/latest/format.html


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
